### PR TITLE
Adding interface `Spiral\RoadRunner\Tcp\RequestInterface`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 .idea
+build
 vendor
 composer.lock
 .phpunit.cache/

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Spiral Scout
+Copyright (c) 2024 Spiral Scout
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -7,8 +7,14 @@
 
 # RoadRunner TCP Plugin
 
-[![Latest Stable Version](https://poser.pugx.org/spiral/roadrunner-tcp/version)](https://packagist.org/packages/spiral/roadrunner-tcp)
-[![Build Status](https://github.com/spiral/roadrunner-tcp/workflows/build/badge.svg)](https://github.com/spiral/roadrunner-tcp/actions)
+[![PHP Version Require](https://poser.pugx.org/spiral/roadrunner-tcp/require/php)](https://packagist.org/packages/spiral/roadrunner-tcp)
+[![Latest Stable Version](https://poser.pugx.org/spiral/roadrunner-tcp/v/stable)](https://packagist.org/packages/spiral/roadrunner-tcp)
+[![phpunit](https://github.com/spiral/roadrunner-tcp/actions/workflows/phpunit.yml/badge.svg)](https://github.com/spiral/roadrunner-tcp/actions)
+[![psalm](https://github.com/spiral/roadrunner-tcp/actions/workflows/psalm.yml/badge.svg)](https://github.com/spiral/roadrunner-tcp/actions)
+[![Codecov](https://codecov.io/gh/spiral/roadrunner-tcp/branch/3.x/graph/badge.svg)](https://codecov.io/gh/spiral/roadrunner-tcp)
+[![Total Downloads](https://poser.pugx.org/spiral/roadrunner-tcp/downloads)](https://packagist.org/packages/spiral/roadrunner-tcp)
+[![type-coverage](https://shepherd.dev/github/spiral/roadrunner-tcp/coverage.svg)](https://shepherd.dev/github/spiral/roadrunner-tcp)
+[![psalm-level](https://shepherd.dev/github/spiral/roadrunner-tcp/level.svg)](https://shepherd.dev/github/spiral/roadrunner-tcp)
 
 RoadRunner is an open-source (MIT licensed) high-performance PHP application server, load balancer, and process manager.
 It supports running as a service with the ability to extend its functionality on a per-project basis.
@@ -28,19 +34,19 @@ to get application server.
 To install application server and TCP codebase:
 
 ```bash
-$ composer require spiral/roadrunner-tcp
+composer require spiral/roadrunner-tcp
 ```
 
 You can use the convenient installer to download the latest available compatible version of RoadRunner assembly:
 
 ```bash
-$ composer require spiral/roadrunner-cli --dev
+composer require spiral/roadrunner-cli --dev
 ```
 
 To download latest version of application server:
 
 ```bash
-$ vendor/bin/rr get
+vendor/bin/rr get
 ```
 
 ## Usage
@@ -90,7 +96,7 @@ while ($request = $tcpWorker->waitRequest()) {
     try {
         if ($request->event === TcpEvent::Connected) {
             // You can close connection according your restrictions
-            if ($request->remoteAddr !== '127.0.0.1') {
+            if ($request->getRemoteAddress() !== '127.0.0.1') {
                 $tcpWorker->close();
                 continue;
             }
@@ -106,31 +112,31 @@ while ($request = $tcpWorker->waitRequest()) {
             // Or send response to the TCP connection, for example, to the SMTP client
             $tcpWorker->respond("220 mailamie \r\n");
             
-        } elseif ($request->event === TcpEvent::Data) {
+        } elseif ($request->getEvent() === TcpEvent::Data) {
                    
-            $body = $request->body;
+            $body = $request->getBody();
             
             // ... handle request from TCP server [tcp_access_point_1]
-            if ($request->server === 'tcp_access_point_1') {
+            if ($request->getServer() === 'tcp_access_point_1') {
 
                 // Send response and close connection
                 $tcpWorker->respond('Access denied', TcpResponse::RespondClose);
                
             // ... handle request from TCP server [server2] 
-            } elseif ($request->server === 'server2') {
+            } elseif ($request->getServer() === 'server2') {
                 
                 // Send response to the TCP connection and wait for the next request
                 $tcpWorker->respond(\json_encode([
-                    'remote_addr' => $request->remoteAddr,
-                    'server' => $request->server,
-                    'uuid' => $request->connectionUuid,
-                    'body' => $request->body,
-                    'event' => $request->event
+                    'remote_addr' => $request->getRemoteAddress(),
+                    'server' => $request->getServer(),
+                    'uuid' => $request->getConnectionUuid(),
+                    'body' => $request->getBody(),
+                    'event' => $request->getEvent()
                 ]));
             }
            
         // Handle closed connection event 
-        } elseif ($request->event === TcpEvent::Close) {
+        } elseif ($request->getEvent() === TcpEvent::Close) {
             // Do something ...
             
             // You don't need to send response on closed connection

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
     },
     "require-dev": {
         "jetbrains/phpstorm-attributes": "^1.0",
-        "phpunit/phpunit": "^10.0",
+        "phpunit/phpunit": "^10.5",
         "vimeo/psalm": ">=5.8"
     },
     "scripts": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,20 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false"
-         colors="true" processIsolation="false" stopOnFailure="false" stopOnError="false" stderr="true"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache"
-         backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         colors="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         stopOnError="false"
+         stderr="false"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false"
+>
     <coverage>
-        <include>
-            <directory>src</directory>
-        </include>
+        <report>
+            <html outputDirectory="build/coverage"/>
+            <text outputFile="build/coverage.txt"/>
+            <clover outputFile="build/logs/clover.xml"/>
+        </report>
     </coverage>
+    <logging>
+        <junit outputFile="build/report.junit.xml"/>
+    </logging>
     <testsuites>
         <testsuite name="Test Suite">
-            <directory suffix="Test.php">tests</directory>
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
     <php>
         <ini name="error_reporting" value="-1"/>
         <ini name="memory_limit" value="-1"/>
     </php>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/Request.php
+++ b/src/Request.php
@@ -47,8 +47,6 @@ final class Request implements RequestInterface
 
     /**
      * Returns the received data from the connection.
-     *
-     * @return non-empty-string
      */
     public function getBody(): string
     {

--- a/src/Request.php
+++ b/src/Request.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Spiral\RoadRunner\Tcp;
 
-final class Request
+final class Request implements RequestInterface
 {
     /**
      * @param non-empty-string $remoteAddr Client IP Address
@@ -14,11 +14,64 @@ final class Request
      * @param non-empty-string $server Server name, which received data
      */
     public function __construct(
+        /** @since 4.0 This property will be private, use {@see getRemoteAddress()} method. */
         public readonly string $remoteAddr,
+        /** @since 4.0 This property will be private, use {@see getEvent()} method. */
         public readonly TcpEvent $event,
+        /** @since 4.0 This property will be private, use {@see getBody()} method. */
         public readonly string $body,
+        /** @since 4.0 This property will be private, use {@see getConnectionUuid()} method. */
         public readonly string $connectionUuid,
+        /** @since 4.0 This property will be private, use {@see getServer()} method. */
         public readonly string $server,
     ) {
+    }
+
+    /**
+     * Returns the client's IP address.
+     *
+     * @return non-empty-string
+     */
+    public function getRemoteAddress(): string
+    {
+        return $this->remoteAddr;
+    }
+
+    /**
+     * Returns the connection event type (CONNECTED, DATA, CLOSED).
+     */
+    public function getEvent(): TcpEvent
+    {
+        return $this->event;
+    }
+
+    /**
+     * Returns the received data from the connection.
+     *
+     * @return non-empty-string
+     */
+    public function getBody(): string
+    {
+        return $this->body;
+    }
+
+    /**
+     * Returns the connection UUID.
+     *
+     * @return non-empty-string
+     */
+    public function getConnectionUuid(): string
+    {
+        return $this->connectionUuid;
+    }
+
+    /**
+     * Returns the server name that received the data.
+     *
+     * @return non-empty-string
+     */
+    public function getServer(): string
+    {
+        return $this->server;
     }
 }

--- a/src/RequestInterface.php
+++ b/src/RequestInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunner\Tcp;
+
+interface RequestInterface
+{
+    /**
+     * Returns the client's IP address.
+     *
+     * @return non-empty-string
+     */
+    public function getRemoteAddress(): string;
+
+    /**
+     * Returns the connection event type (CONNECTED, DATA, CLOSED).
+     */
+    public function getEvent(): TcpEvent;
+
+    /**
+     * Returns the received data from the connection.
+     *
+     * @return non-empty-string
+     */
+    public function getBody(): string;
+
+    /**
+     * Returns the connection UUID.
+     *
+     * @return non-empty-string
+     */
+    public function getConnectionUuid(): string;
+
+    /**
+     * Returns the server name that received the data.
+     *
+     * @return non-empty-string
+     */
+    public function getServer(): string;
+}

--- a/src/RequestInterface.php
+++ b/src/RequestInterface.php
@@ -20,8 +20,6 @@ interface RequestInterface
 
     /**
      * Returns the received data from the connection.
-     *
-     * @return non-empty-string
      */
     public function getBody(): string;
 

--- a/src/TcpWorker.php
+++ b/src/TcpWorker.php
@@ -29,7 +29,7 @@ class TcpWorker implements TcpWorkerInterface
         return $this->worker;
     }
 
-    public function waitRequest(): ?Request
+    public function waitRequest(): ?RequestInterface
     {
         $payload = $this->worker->waitPayload();
 

--- a/src/TcpWorkerInterface.php
+++ b/src/TcpWorkerInterface.php
@@ -11,7 +11,7 @@ interface TcpWorkerInterface extends WorkerAwareInterface
     /**
      * Wait for incoming tcp request.
      */
-    public function waitRequest(): ?Request;
+    public function waitRequest(): ?RequestInterface;
 
     /**
      * Send response to the application server.

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiral\RoadRunner\Tcp\Tests;
+
+use Spiral\RoadRunner\Tcp\Request;
+use Spiral\RoadRunner\Tcp\TcpEvent;
+
+final class RequestTest extends TestCase
+{
+    public function testGetRemoteAddress(): void
+    {
+        $request = new Request('127.0.0.1', TcpEvent::Close, '', '', '');
+
+        $this->assertSame('127.0.0.1', $request->getRemoteAddress());
+    }
+
+    public function testGetEvent(): void
+    {
+        $request = new Request('', TcpEvent::Close, '', '', '');
+
+        $this->assertSame(TcpEvent::Close, $request->getEvent());
+    }
+
+    public function testGetBody(): void
+    {
+        $request = new Request('', TcpEvent::Close, 'foo', '', '');
+
+        $this->assertSame('foo', $request->getBody());
+    }
+
+    public function testGetConnectionUuid(): void
+    {
+        $request = new Request('', TcpEvent::Close, '', 'bar', '');
+
+        $this->assertSame('bar', $request->getConnectionUuid());
+    }
+
+    public function testGetServer(): void
+    {
+        $request = new Request('', TcpEvent::Close, '', '', 'baz');
+
+        $this->assertSame('baz', $request->getServer());
+    }
+}

--- a/tests/TcpWorkerTest.php
+++ b/tests/TcpWorkerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Spiral\RoadRunner\Tcp\Tests;
@@ -9,7 +10,7 @@ use Spiral\RoadRunner\Tcp\TcpResponse;
 use Spiral\RoadRunner\Tcp\TcpWorker;
 use Spiral\RoadRunner\WorkerInterface;
 
-class TcpWorkerTest extends TestCase
+final class TcpWorkerTest extends TestCase
 {
     private TcpWorker $tcpWorker;
     private WorkerInterface $worker;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ❌ 
| New feature?  | ✔️

### What was changed

Added interface `Spiral\RoadRunner\Tcp\RequestInterface`. The class `Spiral\RoadRunner\Tcp\Request` now implements this new interface and continues to be returned in the `Spiral\RoadRunner\Tcp\TcpWorker`.
