### PR TITLE
Change the visibility of properties from public to private

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Latest Stable Version](https://poser.pugx.org/spiral/roadrunner-tcp/v/stable)](https://packagist.org/packages/spiral/roadrunner-tcp)
 [![phpunit](https://github.com/spiral/roadrunner-tcp/actions/workflows/phpunit.yml/badge.svg)](https://github.com/spiral/roadrunner-tcp/actions)
 [![psalm](https://github.com/spiral/roadrunner-tcp/actions/workflows/psalm.yml/badge.svg)](https://github.com/spiral/roadrunner-tcp/actions)
-[![Codecov](https://codecov.io/gh/roadrunner-php/tcp/branch/3.x/graph/badge.svg)](https://codecov.io/gh/roadrunner-php/tcp)
+[![Codecov](https://codecov.io/gh/roadrunner-php/tcp/branch/4.x/graph/badge.svg)](https://codecov.io/gh/roadrunner-php/tcp)
 [![Total Downloads](https://poser.pugx.org/spiral/roadrunner-tcp/downloads)](https://packagist.org/packages/spiral/roadrunner-tcp)
 [![type-coverage](https://shepherd.dev/github/roadrunner-php/tcp/coverage.svg)](https://shepherd.dev/github/spiral/roadrunner-php/tcp)
 [![psalm-level](https://shepherd.dev/github/roadrunner-php/tcp/level.svg)](https://shepherd.dev/github/roadrunner-php/tcp)
@@ -94,7 +94,7 @@ $tcpWorker = new TcpWorker($worker);
 while ($request = $tcpWorker->waitRequest()) {
 
     try {
-        if ($request->event === TcpEvent::Connected) {
+        if ($request->getEvent() === TcpEvent::Connected) {
             // You can close connection according your restrictions
             if ($request->getRemoteAddress() !== '127.0.0.1') {
                 $tcpWorker->close();

--- a/src/Request.php
+++ b/src/Request.php
@@ -14,16 +14,11 @@ final class Request implements RequestInterface
      * @param non-empty-string $server Server name, which received data
      */
     public function __construct(
-        /** @since 4.0 This property will be private, use {@see getRemoteAddress()} method. */
-        public readonly string $remoteAddr,
-        /** @since 4.0 This property will be private, use {@see getEvent()} method. */
-        public readonly TcpEvent $event,
-        /** @since 4.0 This property will be private, use {@see getBody()} method. */
-        public readonly string $body,
-        /** @since 4.0 This property will be private, use {@see getConnectionUuid()} method. */
-        public readonly string $connectionUuid,
-        /** @since 4.0 This property will be private, use {@see getServer()} method. */
-        public readonly string $server,
+        private readonly string $remoteAddr,
+        private readonly TcpEvent $event,
+        private readonly string $body,
+        private readonly string $connectionUuid,
+        private readonly string $server,
     ) {
     }
 

--- a/tests/TcpWorkerTest.php
+++ b/tests/TcpWorkerTest.php
@@ -70,10 +70,10 @@ final class TcpWorkerTest extends TestCase
 
         $request = $this->tcpWorker->waitRequest();
 
-        $this->assertSame($remoteIp, $request->remoteAddr);
-        $this->assertSame($server, $request->server);
-        $this->assertSame($uuid, $request->connectionUuid);
-        $this->assertSame($event, $request->event);
+        $this->assertSame($remoteIp, $request->getRemoteAddress());
+        $this->assertSame($server, $request->getServer());
+        $this->assertSame($uuid, $request->getConnectionUuid());
+        $this->assertSame($event, $request->getEvent());
     }
 
     public function testReadResponse()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bugfix?       | ❌
| Breaks BC?    | ✔️
| New feature?  | ❌ 

The visibility scope of properties in the class `Spiral\RoadRunner\Tcp\Request` has been changed from **public** to **private**. This is a backward compatibility break and will be in release **4.0**.